### PR TITLE
Fix example by replacing `isEmpty` with `isPresent`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ public class Test {
 
         connection = new MySQLConnection(mysql_creds);
         connection.connect(result -> {
-            if (result.getException().isEmpty()) {
+            if (result.getException().isPresent()) {
                 result.getException().get().printStackTrace();
                 return;
             }


### PR DESCRIPTION
In your example, if the exception is empty then you perform a .get() on it, which is a guaranteed NPE

Instead we'll do `isPresent` to fix the example